### PR TITLE
Fix extension detection in get_extension() to properly handle filenam…

### DIFF
--- a/igm_churchill_ancestry/utilities/utilities.py
+++ b/igm_churchill_ancestry/utilities/utilities.py
@@ -55,14 +55,46 @@ def get_extension(path):
     -------
     ext - returns the matched extension (str)
           or signals that the path is a directory
-
     """
+    # Check if path is an existing directory
+    if os.path.isdir(path):
+        return 'dir'
+
+    # Get the basename of the path
+    basename = os.path.basename(path)
+
+    # First try exact suffix matching
     extensions = [x for x in variables.EXTENSIONS if path.endswith(x)]
     if len(extensions) == 1:
         return extensions[0]
-    else:
-        log.debug(f"{path} matches multiple or no extensions {variables.EXTENSIONS}. Assuming directory")
-        return 'dir'
+
+    # If no match, try more flexible matching for compound extensions
+    for ext in variables.EXTENSIONS:
+        # For extensions with multiple parts (like .g.vcf.gz)
+        if '.' in ext[1:]:  # Skip the first dot
+            parts = ext.split('.')
+            # Check if all parts appear in the filename in the right order
+            found = True
+            remaining = basename
+            for part in parts[1:]:  # Skip the empty string before first dot
+                if part not in remaining:
+                    found = False
+                    break
+                remaining = remaining[remaining.index(part) + len(part):]
+
+            if found:
+                return ext
+
+    # If still no match, check if it's an existing file
+    if os.path.isfile(path):
+        # Try to find the closest match to an approved extension
+        for ext in variables.EXTENSIONS:
+            if basename.endswith(ext.split('.')[-1]):  # Match just the final extension part
+                return ext
+
+    # If all else fails, assume it's a directory
+    log.debug(f"{path} matches multiple or no extensions {variables.EXTENSIONS}. Assuming directory")
+    return 'dir'
 
 
 def random_file_code():


### PR DESCRIPTION
Fix file extension detection bug for complex filenames with multiple dots

This PR addresses the issue where complex filenames containing multiple dots (like `sample.hard-filtered.gvcf.gz`) were incorrectly classified as directories. The fix improves the extension detection logic to properly recognize valid genomic variant file formats with compound extensions.